### PR TITLE
Remove About/Services links from navigation

### DIFF
--- a/community.html
+++ b/community.html
@@ -108,8 +108,8 @@
         <nav class="app-menu-dropdown" aria-label="Site">
           <div class="app-grid">
             <a href="index.html" class="app-tile">🏠 Home</a>
-            <a href="about.html" class="app-tile">ℹ️ About</a>
-            <a href="#services" class="app-tile">🛠️ Services</a>
+            <!-- Removed About link as the page is no longer available -->
+            <!-- Removed Services link to simplify navigation -->
             <a href="prompt-library.html" class="app-tile">🧠 Prompt Library</a>
             <a href="gpts.html" class="app-tile">🤖 GPT Tools</a>
             <a href="community.html" class="app-tile">🧑‍🤝‍🧑 Community</a>

--- a/gpts.html
+++ b/gpts.html
@@ -145,8 +145,8 @@
         <nav class="app-menu-dropdown" aria-label="Site">
           <div class="app-grid">
             <a href="index.html" class="app-tile">🏠 Home</a>
-            <a href="about.html" class="app-tile">ℹ️ About</a>
-            <a href="#services" class="app-tile">🛠️ Services</a>
+            <!-- Removed About link as the page is no longer available -->
+            <!-- Removed Services link to simplify navigation -->
             <a href="prompt-library.html" class="app-tile">🧠 Prompt Library</a>
             <a href="gpts.html" class="app-tile">🤖 GPT Tools</a>
             <a href="community.html" class="app-tile">🧑‍🤝‍🧑 Community</a>

--- a/index.html
+++ b/index.html
@@ -245,8 +245,8 @@
         <nav id="site-nav" class="app-menu-dropdown" aria-label="Site">
           <div class="app-grid">
             <a href="index.html" class="app-tile">🏠 Home</a>
-            <a href="about.html" class="app-tile">ℹ️ About</a>
-            <a href="#services" class="app-tile">🛠️ Services</a> <!-- AI: scroll to services section -->
+            <!-- Removed About link as the page is no longer available -->
+            <!-- Removed Services link to simplify navigation -->
             <a href="prompt-library.html" class="app-tile">🧠 Prompt Library</a>
             <a href="gpts.html" class="app-tile">🤖 GPT Tools</a>
             <a href="community.html" class="app-tile">🧑‍🤝‍🧑 Community</a>

--- a/prompt-library.html
+++ b/prompt-library.html
@@ -138,8 +138,8 @@
         <nav class="app-menu-dropdown" aria-label="Site">
           <div class="app-grid">
             <a href="index.html" class="app-tile">🏠 Home</a>
-            <a href="about.html" class="app-tile">ℹ️ About</a>
-            <a href="#services" class="app-tile">🛠️ Services</a>
+            <!-- Removed About link as the page is no longer available -->
+            <!-- Removed Services link to simplify navigation -->
             <a href="prompt-library.html" class="app-tile">🧠 Prompt Library</a>
             <a href="gpts.html" class="app-tile">🤖 GPT Tools</a>
             <a href="community.html" class="app-tile">🧑‍🤝‍🧑 Community</a>


### PR DESCRIPTION
## Summary
- drop About and Services links from all navigation menus

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68751be29318832ab47a55c88c7f9d4d