### PR TITLE
Add placeholder nav links with vertical icons

### DIFF
--- a/community.html
+++ b/community.html
@@ -63,8 +63,10 @@
       padding: 0.75rem 0.5rem;
       font-size: 0.875rem;
       display: flex;
+      flex-direction: column;
       align-items: center;
       justify-content: center;
+      gap: 0.25rem;
     }
     .community-section { padding: 2rem 0; text-align: center; }
     .community-grid {
@@ -107,12 +109,14 @@
         <button id="app-menu-btn" class="app-menu-btn" aria-label="Open site menu" aria-haspopup="true" aria-expanded="false">Navigation</button>
         <nav class="app-menu-dropdown" aria-label="Site">
           <div class="app-grid">
-            <a href="index.html" class="app-tile">🏠 Home</a>
+            <a href="index.html" class="app-tile"><span aria-hidden="true">🏠</span><span>Home</span></a>
             <!-- Removed About link as the page is no longer available -->
             <!-- Removed Services link to simplify navigation -->
-            <a href="prompt-library.html" class="app-tile">🧠 Prompt Library</a>
-            <a href="gpts.html" class="app-tile">🤖 GPT Tools</a>
-            <a href="community.html" class="app-tile">🧑‍🤝‍🧑 Community</a>
+            <a href="prompt-library.html" class="app-tile"><span aria-hidden="true">🧠</span><span>Prompt Library</span></a>
+            <a href="gpts.html" class="app-tile"><span aria-hidden="true">🤖</span><span>GPT Tools</span></a>
+            <a href="community.html" class="app-tile"><span aria-hidden="true">🧑‍🤝‍🧑</span><span>Community</span></a>
+            <a href="#" class="app-tile"><span aria-hidden="true">📦</span><span>Placeholder 1</span></a>
+            <a href="#" class="app-tile"><span aria-hidden="true">🚧</span><span>Placeholder 2</span></a>
           </div>
         </nav>
       </div>

--- a/gpts.html
+++ b/gpts.html
@@ -71,8 +71,10 @@
       padding: 0.75rem 0.5rem;
       font-size: 0.875rem;
       display: flex;
+      flex-direction: column;
       align-items: center;
       justify-content: center;
+      gap: 0.25rem;
     }
     .services-section {
       padding: 2rem 0;
@@ -144,12 +146,14 @@
         <button id="app-menu-btn" class="app-menu-btn" aria-label="Open site menu" aria-haspopup="true" aria-expanded="false">Navigation</button>
         <nav class="app-menu-dropdown" aria-label="Site">
           <div class="app-grid">
-            <a href="index.html" class="app-tile">🏠 Home</a>
+            <a href="index.html" class="app-tile"><span aria-hidden="true">🏠</span><span>Home</span></a>
             <!-- Removed About link as the page is no longer available -->
             <!-- Removed Services link to simplify navigation -->
-            <a href="prompt-library.html" class="app-tile">🧠 Prompt Library</a>
-            <a href="gpts.html" class="app-tile">🤖 GPT Tools</a>
-            <a href="community.html" class="app-tile">🧑‍🤝‍🧑 Community</a>
+            <a href="prompt-library.html" class="app-tile"><span aria-hidden="true">🧠</span><span>Prompt Library</span></a>
+            <a href="gpts.html" class="app-tile"><span aria-hidden="true">🤖</span><span>GPT Tools</span></a>
+            <a href="community.html" class="app-tile"><span aria-hidden="true">🧑‍🤝‍🧑</span><span>Community</span></a>
+            <a href="#" class="app-tile"><span aria-hidden="true">📦</span><span>Placeholder 1</span></a>
+            <a href="#" class="app-tile"><span aria-hidden="true">🚧</span><span>Placeholder 2</span></a>
           </div>
         </nav>
       </div>

--- a/index.html
+++ b/index.html
@@ -72,8 +72,10 @@
       padding: 0.75rem 0.5rem;
       font-size: 0.875rem;
       display: flex;
+      flex-direction: column;
       align-items: center;
       justify-content: center;
+      gap: 0.25rem;
     }
     .hero-section {
       background: #f9f9f9;
@@ -244,12 +246,14 @@
         <button id="app-menu-btn" class="app-menu-btn" type="button" aria-label="Open site menu" aria-haspopup="true" aria-expanded="false" aria-controls="site-nav">Navigation</button> <!-- REVIEW: specify button type to prevent form submission -->
         <nav id="site-nav" class="app-menu-dropdown" aria-label="Site">
           <div class="app-grid">
-            <a href="index.html" class="app-tile">🏠 Home</a>
+            <a href="index.html" class="app-tile"><span aria-hidden="true">🏠</span><span>Home</span></a>
             <!-- Removed About link as the page is no longer available -->
             <!-- Removed Services link to simplify navigation -->
-            <a href="prompt-library.html" class="app-tile">🧠 Prompt Library</a>
-            <a href="gpts.html" class="app-tile">🤖 GPT Tools</a>
-            <a href="community.html" class="app-tile">🧑‍🤝‍🧑 Community</a>
+            <a href="prompt-library.html" class="app-tile"><span aria-hidden="true">🧠</span><span>Prompt Library</span></a>
+            <a href="gpts.html" class="app-tile"><span aria-hidden="true">🤖</span><span>GPT Tools</span></a>
+            <a href="community.html" class="app-tile"><span aria-hidden="true">🧑‍🤝‍🧑</span><span>Community</span></a>
+            <a href="#" class="app-tile"><span aria-hidden="true">📦</span><span>Placeholder 1</span></a>
+            <a href="#" class="app-tile"><span aria-hidden="true">🚧</span><span>Placeholder 2</span></a>
           </div>
         </nav>
       </div>

--- a/prompt-library.html
+++ b/prompt-library.html
@@ -65,8 +65,10 @@
       padding: 0.75rem 0.5rem;
       font-size: 0.875rem;
       display: flex;
+      flex-direction: column;
       align-items: center;
       justify-content: center;
+      gap: 0.25rem;
     }
     .prompt-section { padding: 2rem 0; }
     .prompt-form label {
@@ -137,12 +139,14 @@
         <button id="app-menu-btn" class="app-menu-btn" aria-label="Open site menu" aria-haspopup="true" aria-expanded="false">Navigation</button>
         <nav class="app-menu-dropdown" aria-label="Site">
           <div class="app-grid">
-            <a href="index.html" class="app-tile">🏠 Home</a>
+            <a href="index.html" class="app-tile"><span aria-hidden="true">🏠</span><span>Home</span></a>
             <!-- Removed About link as the page is no longer available -->
             <!-- Removed Services link to simplify navigation -->
-            <a href="prompt-library.html" class="app-tile">🧠 Prompt Library</a>
-            <a href="gpts.html" class="app-tile">🤖 GPT Tools</a>
-            <a href="community.html" class="app-tile">🧑‍🤝‍🧑 Community</a>
+            <a href="prompt-library.html" class="app-tile"><span aria-hidden="true">🧠</span><span>Prompt Library</span></a>
+            <a href="gpts.html" class="app-tile"><span aria-hidden="true">🤖</span><span>GPT Tools</span></a>
+            <a href="community.html" class="app-tile"><span aria-hidden="true">🧑‍🤝‍🧑</span><span>Community</span></a>
+            <a href="#" class="app-tile"><span aria-hidden="true">📦</span><span>Placeholder 1</span></a>
+            <a href="#" class="app-tile"><span aria-hidden="true">🚧</span><span>Placeholder 2</span></a>
           </div>
         </nav>
       </div>


### PR DESCRIPTION
## Summary
- adjust `.app-tile` styles so emoji sit above link labels
- add two placeholder links in site navigation
- update every HTML file with navigation to use the new layout

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68751d93da90832a8c9b1d064c723066