### PR TITLE
Add image for UK Co-Creator tile

### DIFF
--- a/gpts.html
+++ b/gpts.html
@@ -129,6 +129,12 @@
       padding: 1rem;
       backface-visibility: hidden;
     }
+    .flip-front img {
+      max-width: 100%;
+      max-height: 100%;
+      object-fit: cover;
+      border-radius: 6px;
+    }
     .flip-back {
       transform: rotateY(180deg);
     }
@@ -172,6 +178,8 @@
           <article class="flip-card">
             <div class="flip-inner">
               <div class="flip-front">
+                <!-- AI: Added UK Co-Creator image -->
+                <img src="https://photos.app.goo.gl/NSPvbo9pWLft3Nfv6" alt="UK Co-Creator image" />
                 <h4>UK Co-Creator for Better AI Outputs</h4>
               </div>
               <div class="flip-back">


### PR DESCRIPTION
## Summary
- show the UK Co-Creator image on the GPT Tools page
- keep the image visually contained with new CSS rules

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687527616df4832a879a6727ec53b509