### PR TITLE
Add cookie consent snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ This website is designed to:
 - Newsletter sign-up and contact forms
 - Cookie consent (GDPR-compliant)
 - Fully responsive and accessibility-conscious design
+- Example cookie banner snippet in `cookie-banner-snippet.html`
 
 ---
 

--- a/cookie-banner-snippet.html
+++ b/cookie-banner-snippet.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Cookie Banner Example</title>
+  <style>
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+      margin: 0;
+    }
+    #cookie-banner {
+      position: fixed;
+      bottom: 0;
+      left: 0;
+      right: 0;
+      background: #f2f2f2;
+      color: #333;
+      display: none;
+      padding: 1rem;
+      box-shadow: 0 -2px 5px rgba(0,0,0,0.1);
+      z-index: 100;
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+    }
+    #cookie-banner button {
+      margin-left: 0.5rem;
+      border: none;
+      border-radius: 4px;
+      padding: 0.5rem 1rem;
+      cursor: pointer;
+      font-size: 1rem;
+    }
+    #cookie-banner .accept {
+      background: #333;
+      color: #fff;
+    }
+    #cookie-banner .reject {
+      background: #e0e0e0;
+      color: #333;
+    }
+    #cookie-banner a {
+      color: #333;
+    }
+  </style>
+</head>
+<body>
+  <h1>Example Page</h1>
+  <p>This is a demonstration of a cookie consent banner.</p>
+
+  <div id="cookie-banner" role="dialog" aria-live="polite" aria-label="Cookie consent">
+    <span>This site uses cookies to improve your experience. <a href="/privacy-policy">Learn more</a>.</span>
+    <div style="margin-left:auto;">
+      <button class="accept" type="button">Accept</button>
+      <button class="reject" type="button">Reject</button>
+    </div>
+  </div>
+
+  <script>
+    // AI: simple cookie banner
+    (function() {
+      const key = 'cookie_choice';
+      const banner = document.getElementById('cookie-banner');
+      const acceptBtn = banner.querySelector('.accept');
+      const rejectBtn = banner.querySelector('.reject');
+
+      if (!localStorage.getItem(key)) {
+        banner.style.display = 'flex';
+      }
+
+      function setChoice(value) {
+        localStorage.setItem(key, value);
+        banner.style.display = 'none';
+      }
+
+      acceptBtn.addEventListener('click', function() { setChoice('accepted'); });
+      rejectBtn.addEventListener('click', function() { setChoice('rejected'); });
+    })();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add simple cookie banner example page
- mention snippet in README

## Testing
- `ls -1 | head`

------
https://chatgpt.com/codex/tasks/task_e_68855908539c832ab93e4aa8d48930f1