### PR TITLE
Add service tiles flip hint

### DIFF
--- a/index.html
+++ b/index.html
@@ -150,6 +150,30 @@
     .flip-card {
       perspective: 1000px;
     }
+    .service-icon {
+      font-size: 2rem;
+      display: block;
+      margin-bottom: 0.5rem;
+    }
+    .flip-hint {
+      position: absolute;
+      bottom: 0.5rem;
+      right: 0.5rem;
+      font-size: 0.875rem;
+      opacity: 0.7;
+      pointer-events: none;
+    }
+    .sr-only {
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      padding: 0;
+      margin: -1px;
+      overflow: hidden;
+      clip: rect(0, 0, 0, 0);
+      white-space: nowrap;
+      border: 0;
+    }
     .flip-inner {
       position: relative;
       width: 100%;
@@ -282,7 +306,9 @@
     <article class="flip-card" tabindex="0" role="button"> <!-- REVIEW: allow keyboard activation -->
       <div class="flip-inner">
         <div class="flip-front">
+          <span class="service-icon" aria-hidden="true">🧭</span>
           <h4>AI Strategy &amp; Roadmapping</h4>
+          <span class="flip-hint"><span class="sr-only">Flip for info</span>↷</span>
         </div>
         <div class="flip-back">
           <p>We help you map out where AI fits into your business — responsibly, practically, and with long-term value.</p>
@@ -292,7 +318,9 @@
     <article class="flip-card" tabindex="0" role="button">
       <div class="flip-inner">
         <div class="flip-front">
+          <span class="service-icon" aria-hidden="true">🔍</span>
           <h4>Automation Audits</h4>
+          <span class="flip-hint"><span class="sr-only">Flip for info</span>↷</span>
         </div>
         <div class="flip-back">
           <p>We assess where time and money are being wasted — then help you streamline with smart automation.</p>
@@ -302,7 +330,9 @@
     <article class="flip-card" tabindex="0" role="button">
       <div class="flip-inner">
         <div class="flip-front">
+          <span class="service-icon" aria-hidden="true">🛠️</span>
           <h4>Tool Setup &amp; Support</h4>
+          <span class="flip-hint"><span class="sr-only">Flip for info</span>↷</span>
         </div>
         <div class="flip-back">
           <p>From GPTs to full-stack tools, we help you implement and manage AI tech that works for your needs.</p>
@@ -312,7 +342,9 @@
     <article class="flip-card" tabindex="0" role="button">
       <div class="flip-inner">
         <div class="flip-front">
+          <span class="service-icon" aria-hidden="true">⚖️</span>
           <h4>Ethical AI Consulting</h4>
+          <span class="flip-hint"><span class="sr-only">Flip for info</span>↷</span>
         </div>
         <div class="flip-back">
           <p>We advise on AI use that’s transparent, inclusive, and aligned with UK business values and data ethics.</p>


### PR DESCRIPTION
## Summary
- style flip hint arrow in service tiles
- visually mark each service tile with an arrow showing it flips for info

## Testing
- `tidy -qe index.html` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68855b186998832abc9fcddd8f676917