### PR TITLE
Add backgrounds for LinkedIn and Teams tiles

### DIFF
--- a/community.html
+++ b/community.html
@@ -87,6 +87,15 @@
       border-radius: 8px;
       box-shadow: 0 2px 6px rgba(0,0,0,0.1);
       padding: 2rem 1rem;
+      background-size: cover;
+      background-position: center;
+      color: #fff;
+    }
+    .community-tile.linkedin {
+      background-image: url("images/linkend in comunity.png");
+    }
+    .community-tile.teams {
+      background-image: url("images/teams comunity.png");
     }
     .community-tile .icon {
       font-size: 48px;
@@ -141,13 +150,13 @@
         <h2>Join the SereneAI Community</h2>
         <p class="intro">Connect with like-minded people across the UK. Choose the space that suits you best.</p>
         <div class="community-grid">
-          <div class="community-tile">
+          <div class="community-tile linkedin">
             <div class="icon" role="img" aria-label="LinkedIn icon">🔗</div>
             <h3>LinkedIn Community</h3>
             <p>Your place to find like-minded UK people.</p>
             <a class="cta-button" href="#">Join on LinkedIn</a>
           </div>
-          <div class="community-tile">
+          <div class="community-tile teams">
             <div class="icon" role="img" aria-label="Teams icon">💬</div>
             <h3>Teams Community</h3>
             <p>Your free place for support and community.</p>


### PR DESCRIPTION
## Summary
- add background images for the LinkedIn and Teams community tiles
- assign classes for LinkedIn and Teams tiles in the markup

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68867dd01770832ab2b0d49f777f575a