### PR TITLE
Add backgrounds for LinkedIn and Teams tiles

### DIFF
--- a/community.html
+++ b/community.html
@@ -82,17 +82,34 @@
     @media (min-width: 600px) {
       .community-grid { grid-template-columns: repeat(2, 1fr); }
     }
+    .community-item {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 0.5rem;
+    }
     .community-tile {
       background: #f0f0f0;
       border-radius: 8px;
       box-shadow: 0 2px 6px rgba(0,0,0,0.1);
       padding: 2rem 1rem;
+      background-size: cover;
+      background-position: center;
+      color: #fff;
+      display: flex;
+      justify-content: center;
     }
-    .community-tile .icon {
+    .community-tile.linkedin {
+      background-image: url("images/linkend in comunity.png");
+    }
+    .community-tile.teams {
+      background-image: url("images/teams comunity.png");
+    }
+    .community-item .icon {
       font-size: 48px;
       margin-bottom: 0.5rem;
     }
-    .community-tile h3 {
+    .community-item h3 {
       margin: 0 0 0.5rem 0;
     }
     .cta-button {
@@ -141,17 +158,21 @@
         <h2>Join the SereneAI Community</h2>
         <p class="intro">Connect with like-minded people across the UK. Choose the space that suits you best.</p>
         <div class="community-grid">
-          <div class="community-tile">
+          <div class="community-item">
             <div class="icon" role="img" aria-label="LinkedIn icon">🔗</div>
             <h3>LinkedIn Community</h3>
             <p>Your place to find like-minded UK people.</p>
-            <a class="cta-button" href="#">Join on LinkedIn</a>
+            <div class="community-tile linkedin">
+              <a class="cta-button" href="#">Join on LinkedIn</a>
+            </div>
           </div>
-          <div class="community-tile">
+          <div class="community-item">
             <div class="icon" role="img" aria-label="Teams icon">💬</div>
             <h3>Teams Community</h3>
             <p>Your free place for support and community.</p>
-            <a class="cta-button" href="#">Join on Teams</a>
+            <div class="community-tile teams">
+              <a class="cta-button" href="#">Join on Teams</a>
+            </div>
           </div>
         </div>
       </section>


### PR DESCRIPTION
## Summary
- add background images for the LinkedIn and Teams community tiles
- assign classes for LinkedIn and Teams tiles in the markup
- move text out of image tiles so only the join button overlays each image

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_68867dd01770832ab2b0d49f777f575a